### PR TITLE
Prevent creating table metadata with nanosecond timestamps before v3

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -51,7 +51,7 @@ public class TableMetadata implements Serializable {
   static final long INITIAL_SEQUENCE_NUMBER = 0;
   static final long INVALID_SEQUENCE_NUMBER = -1;
   static final int DEFAULT_TABLE_FORMAT_VERSION = 2;
-  static final int SUPPORTED_TABLE_FORMAT_VERSION = 2;
+  static final int SUPPORTED_TABLE_FORMAT_VERSION = 3;
   static final int INITIAL_SPEC_ID = 0;
   static final int INITIAL_SORT_ORDER_ID = 1;
   static final int INITIAL_SCHEMA_ID = 0;
@@ -1488,6 +1488,8 @@ public class TableMetadata implements Serializable {
           "Invalid last column ID: %s < %s (previous last column ID)",
           newLastColumnId,
           lastColumnId);
+
+      Schema.checkCompatibility(schema, formatVersion);
 
       int newSchemaId = reuseOrCreateNewSchemaId(schema);
       boolean schemaFound = schemasById.containsKey(newSchemaId);

--- a/core/src/test/resources/TableMetadataUnsupportedVersion.json
+++ b/core/src/test/resources/TableMetadataUnsupportedVersion.json
@@ -1,5 +1,5 @@
 {
-  "format-version": 3,
+  "format-version": 10,
   "table-uuid": "d20125c8-7284-442c-9aea-15fee620737c",
   "location": "s3://bucket/test/location",
   "last-updated-ms": 1602638573874,


### PR DESCRIPTION
This PR fixes https://github.com/apache/iceberg/issues/10775 by validating schemas added to table metadata in `TableMetadata.Builder`.

This also required allowing v3 when creating table metadata and updating the unsupported metadata test case (which used v3 that is now allowed).